### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Evidence retrieval and claim verification are sometimes tackled as a single task
 
 ## Datasets
 ### Claim Detection Dataset
+* SciTweets - A Dataset and Annotation Framework for Detecting Scientific Online Discourse (Hafid et al., 2022)
+  [[Paper]](https://arxiv.org/pdf/2206.07360.pdf)
+  [[Dataset]](https://github.com/AI-4-Sci/SciTweets)
+    **CIKM 2022**
 * Empowering the Fact-checkers! Automatic Identification of Claim Spans on Twitter (Sundriyal et al., 2022)
   [[Paper]](https://arxiv.org/pdf/2210.04710.pdf)
   [[Dataset]](https://github.com/LCS2-IIITD/DABERTA-EMNLP-2022)
@@ -382,6 +386,10 @@ Evidence retrieval and claim verification are sometimes tackled as a single task
 ## Models
 
 ### Claim Detection
+* SciTweets - A Dataset and Annotation Framework for Detecting Scientific Online Discourse (Hafid et al., 2022)
+  [[Paper]](https://arxiv.org/pdf/2206.07360.pdf)
+  [[Code]](https://github.com/AI-4-Sci/SciTweets)
+    **CIKM 2022**
 * Zoom Out and Observe: News Environment Perception for Fake News Detection (Sheng et al., 2022)
   [[Paper]](https://arxiv.org/pdf/2203.10885.pdf)
   [[Code]](https://github.com/ICTMCG/News-Environment-Perception/)


### PR DESCRIPTION
Added the paper "SciTweets - A Dataset and Annotation Framework for Detecting Scientific Online Discourse" (Hafid et al., 2022) which my colleagues and I published at CIKM'22. The contribution includes a dataset which contains scientific claims as they naturally occur on Twitter, as well as an annotation protocol to label scientific claims and a made-publicly-available classifier to detect scientific claims. As the contribution includes both a dataset and a classifier, I included the paper in both the "Claim Detection Models" and "Claim Detection Datasets" sections.